### PR TITLE
Add color customization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.15'
+def runeLiteVersion = '1.6.26.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.26.1'
+def runeLiteVersion = '1.6.27'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/github/m0bilebtw/SkillsTabProgressBarsConfig.java
+++ b/src/main/java/com/github/m0bilebtw/SkillsTabProgressBarsConfig.java
@@ -4,28 +4,45 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Range;
+import net.runelite.client.config.Alpha;
+import java.awt.Color;
 
-@ConfigGroup("skillstabprogressbars")
+@ConfigGroup(SkillsTabProgressBarsConfig.GROUP)
 public interface SkillsTabProgressBarsConfig extends Config {
 
-    @ConfigItem(
-            keyName = "drawBackgrounds",
-            name = "Draw progress bar backgrounds",
-            description = "Draw a background behind each progress bar for better visibility",
-            position = 1
-    )
-    default boolean drawBackgrounds() {
-        return true;
-    }
+	String GROUP = "skillstabprogressbars";
 
+	@Alpha
+	@ConfigItem(
+			keyName = "progressBarStartColor",
+			name = "Start color",
+			description = "The color from which the progress bar fades.",
+			position = 0
+	)
+	default Color progressBarStartColor() {
+		return new Color(0xFFFF0000);
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "progressBarEndColor",
+			name = "End color",
+			description = "The color to which the progress bar fades.",
+			position = 1
+	)
+	default Color progressBarEndColor() {
+		return new Color(0xFF00FF00);
+	}
+
+	@Alpha
     @ConfigItem(
-            keyName = "transparency",
-            name = "Transparency",
-            description = "Progress bars and backgrounds will have transparency",
+            keyName = "backgroundColor",
+            name = "Background color",
+            description = "Sets the color for the background drawn behind progress bars.",
             position = 2
     )
-    default boolean transparency() {
-        return false;
+    default Color backgroundColor() {
+        return Color.BLACK;
     }
 
     @ConfigItem(
@@ -71,5 +88,27 @@ public interface SkillsTabProgressBarsConfig extends Config {
     default boolean showGoals() {
         return false;
     }
+
+	@Alpha
+	@ConfigItem(
+			keyName = "goalBarStartColor",
+			name = "Goal start color",
+			description = "The color from which the goal bar fades.",
+			position = 7
+	)
+	default Color goalBarStartColor() {
+		return new Color(0xFF0000FF);
+	}
+
+	@Alpha
+	@ConfigItem(
+			keyName = "goalBarEndColor",
+			name = "Goal end color",
+			description = "The color to which the goal bar fades.",
+			position = 8
+	)
+	default Color goalBarEndColor() {
+		return new Color(0xFFFF0080);
+	}
 }
 

--- a/src/main/java/com/github/m0bilebtw/SkillsTabProgressBarsPlugin.java
+++ b/src/main/java/com/github/m0bilebtw/SkillsTabProgressBarsPlugin.java
@@ -14,6 +14,7 @@ import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -76,6 +77,13 @@ public class SkillsTabProgressBarsPlugin extends Plugin {
 	public void onStatChanged(StatChanged statChanged) {
 		calculateAndStoreProgressToLevel(statChanged.getSkill(), statChanged.getXp());
 		calculateAndStoreProgressToGoal(statChanged.getSkill(), statChanged.getXp());
+	}
+
+	@Subscribe
+	public void onConfigChanged(ConfigChanged event) {
+		if (event.getGroup().equalsIgnoreCase(SkillsTabProgressBarsConfig.GROUP)) {
+			overlay.generateHSBAComponents();
+		}
 	}
 
 	private void calculateAndStoreProgressForAllSkillsToLevel() {


### PR DESCRIPTION
This will add color and alpha customization to all options. I've maintained the default colors and transition/fade methodology, so by default the appearance should be the same withholding a few small changes. 
Here's a short summary of the changes I've made:
- Custom color start and end points for progress.
- Custom color start and end points for goals.
- Fading between two different custom set alpha values
- Custom color for background. I've removed the transparency toggle with this, as the user can now simply set the alpha to 0.
- HSBA values for colors stored as member arrays instead of being hardcoded.
 
Closes #5 

scrot with config options and skills window:
![2020-09-23-215653_1234x944_scrot](https://user-images.githubusercontent.com/66925241/94022199-5cb43800-fda4-11ea-8df8-5983c3fcb7af.png)

